### PR TITLE
Use *.member, not *.peer as NodeOU support not enabled (resolves #130)

### DIFF
--- a/one-org-network/playbook.yml
+++ b/one-org-network/playbook.yml
@@ -144,7 +144,7 @@
         package: "{{ playbook_dir }}/fabcar@1.0.0.cds"
         channels:
           - <<: *Channel1
-            endorsement_policy: "AND('Org1MSP.peer')"
+            endorsement_policy: "AND('Org1MSP.member')"
             endorsing_members:
               - <<: *Org1
                 endorsing_peers:

--- a/two-org-network/playbook.yml
+++ b/two-org-network/playbook.yml
@@ -217,7 +217,7 @@
         package: "{{ playbook_dir }}/fabcar@1.0.0.cds"
         channels:
           - <<: *Channel1
-            endorsement_policy: "AND('Org1MSP.peer','Org2MSP.peer')"
+            endorsement_policy: "AND('Org1MSP.member','Org2MSP.member')"
             endorsing_members:
               - <<: *Org1
                 endorsing_peers:


### PR DESCRIPTION
Signed-off-by: Simon Stone <sstone1@uk.ibm.com>